### PR TITLE
refector: enlarge the validation time of jwt from 1 second to 30 minutes

### DIFF
--- a/src/main/java/com/jinro/webide/login/service/JwtService.java
+++ b/src/main/java/com/jinro/webide/login/service/JwtService.java
@@ -47,7 +47,7 @@ public class JwtService {
                 .claim("name", name)
                 .setSubject(userDetails.getUsername())
                 .setIssuedAt(new Date(System.currentTimeMillis()))
-                .setExpiration(new Date(System.currentTimeMillis() + 1000 * 60 * 1))
+                .setExpiration(new Date(System.currentTimeMillis() + 1000 * 60 * 30))
                 .signWith(getSignInKey(), SignatureAlgorithm.HS256)
                 .compact();
     }


### PR DESCRIPTION
##Summary
- JWT 유효시간을 1초에서 30분으로 늘렸습니다.